### PR TITLE
Add a script to simulate voting traffic

### DIFF
--- a/emojivoto/common.mk
+++ b/emojivoto/common.mk
@@ -17,7 +17,7 @@ protoc:
 package: protoc dep compile build-container
 
 build-container:
-	docker build .. -t "buoyantio/$(svc_name):v1" --build-arg svc_name=$(svc_name)
+	docker build .. -t "buoyantio/$(svc_name):v2" --build-arg svc_name=$(svc_name)
 
 compile:
 	GOOS=linux go build -v -o $(target_dir)/$(svc_name) cmd/server.go

--- a/emojivoto/docker-compose.yml
+++ b/emojivoto/docker-compose.yml
@@ -14,6 +14,15 @@ services:
       - voting-svc
       - emoji-svc
 
+  vote-bot:
+    image: buoyantio/emojivoto-web:v1
+    entrypoint: emojivoto-vote-bot
+    command:
+      - "-sleep=1s"
+      - "web:8080"
+    depends_on:
+      - web
+
   emoji-svc:
     image: buoyantio/emojivoto-emoji-svc:v1
     environment:

--- a/emojivoto/docker-compose.yml
+++ b/emojivoto/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   web:
-    image: buoyantio/emojivoto-web:v1
+    image: buoyantio/emojivoto-web:v2
     environment:
       - WEB_PORT=8080
       - EMOJISVC_HOST=emoji-svc:8080
@@ -15,23 +15,22 @@ services:
       - emoji-svc
 
   vote-bot:
-    image: buoyantio/emojivoto-web:v1
+    image: buoyantio/emojivoto-web:v2
     entrypoint: emojivoto-vote-bot
-    command:
-      - "-sleep=1s"
-      - "web:8080"
+    environment:
+      - WEB_HOST=web:8080
     depends_on:
       - web
 
   emoji-svc:
-    image: buoyantio/emojivoto-emoji-svc:v1
+    image: buoyantio/emojivoto-emoji-svc:v2
     environment:
       - GRPC_PORT=8080
     ports:
       - "8081:8080"
 
   voting-svc:
-    image: buoyantio/emojivoto-voting-svc:v1
+    image: buoyantio/emojivoto-voting-svc:v2
     environment:
       - GRPC_PORT=8080
     ports:

--- a/emojivoto/emojivoto-web/Makefile
+++ b/emojivoto/emojivoto-web/Makefile
@@ -11,3 +11,8 @@ package-web: webpack
 	mkdir -p $(target_dir)/web
 	cp web/favicon.ico $(target_dir)/web
 	cp -a webapp/dist $(target_dir)
+
+compile-vote-bot:
+	GOOS=linux go build -v -o $(target_dir)/emojivoto-vote-bot cmd/vote-bot/main.go
+
+compile: compile-vote-bot

--- a/emojivoto/emojivoto-web/cmd/vote-bot/main.go
+++ b/emojivoto/emojivoto-web/cmd/vote-bot/main.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+)
+
+// VoteBot votes for emoji! :ballot_box_with_check:
+//
+// Sadly, VoteBot has a sweet tooth and votes for :doughnut: 15% of the time.
+// Furthermore, VoteBot is juvenile and votes for :poop: 20% of the time.
+//
+// When not voting for :doughnut: or :poop:, VoteBot can’t be bothered to
+// pick a favorite, so it picks one at random. C'mon VoteBot, try harder!
+
+type emoji struct {
+	Shortcode string
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+
+	var sleep = flag.Duration("sleep", 100*time.Millisecond, "time to sleep between votes")
+
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: emojivoto-vote-bot [options] <target>\n")
+		fmt.Fprintf(os.Stderr, "       where <target> is host:port of web service, and [options] include:\n")
+		flag.PrintDefaults()
+	}
+
+	flag.Parse()
+	if flag.NArg() != 1 {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	host := "http://" + flag.Arg(0)
+	if _, err := url.Parse(host); err != nil {
+		fmt.Fprintf(os.Stderr, "Invalid target: %s\n", flag.Arg(0))
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	for {
+		time.Sleep(*sleep)
+
+		// Get the list of available shortcodes
+		shortcodes, err := shortcodes(host)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			continue
+		}
+
+		// Cast a vote
+		probability := rand.Float32()
+		switch {
+		case probability < 0.15:
+			err = vote(host, ":doughnut:")
+		case probability < 0.35:
+			err = vote(host, ":poop:")
+		default:
+			random := shortcodes[rand.Intn(len(shortcodes))]
+			err = vote(host, random)
+		}
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			continue
+		}
+
+		// Get the leaderboard
+		err = leaderboard(host)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			continue
+		}
+	}
+}
+
+func shortcodes(host string) ([]string, error) {
+	url := fmt.Sprintf("%s/api/list", host)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	bytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var emojis []*emoji
+	err = json.Unmarshal(bytes, &emojis)
+	if err != nil {
+		return nil, err
+	}
+
+	shortcodes := make([]string, len(emojis))
+	for i, e := range emojis {
+		shortcodes[i] = e.Shortcode
+	}
+
+	return shortcodes, nil
+}
+
+func vote(host string, shortcode string) error {
+	fmt.Printf("✔ Voting for %s\n", shortcode)
+	url := fmt.Sprintf("%s/api/vote?choice=%s", host, shortcode)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func leaderboard(host string) error {
+	url := fmt.Sprintf("%s/api/leaderboard", host)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return nil
+}

--- a/emojivoto/emojivoto.yml
+++ b/emojivoto/emojivoto.yml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: emoji-svc
-        image: buoyantio/emojivoto-emoji-svc:v1
+        image: buoyantio/emojivoto-emoji-svc:v2
         env:
         - name: GRPC_PORT
           value: "8080"
@@ -60,7 +60,7 @@ spec:
     spec:
       containers:
       - name: voting-svc
-        image: buoyantio/emojivoto-voting-svc:v1
+        image: buoyantio/emojivoto-voting-svc:v2
         env:
         - name: GRPC_PORT
           value: "8080"
@@ -99,7 +99,7 @@ spec:
     spec:
       containers:
       - name: web-svc
-        image: buoyantio/emojivoto-web:v1
+        image: buoyantio/emojivoto-web:v2
         env:
         - name: WEB_PORT
           value: "80"
@@ -113,14 +113,11 @@ spec:
         - name: http
           containerPort: 80
       - name: vote-bot
-        image: buoyantio/emojivoto-web:v1
-        command:
-        - "/bin/sh"
-        args:
-        - "-c"
-        - |
-          sleep 15 # wait for pods to start
-          emojivoto-vote-bot localhost:80
+        image: buoyantio/emojivoto-web:v2
+        command: ["emojivoto-vote-bot"]
+        env:
+        - name: WEB_HOST
+          value: "localhost:80"
 ---
 apiVersion: v1
 kind: Service

--- a/emojivoto/emojivoto.yml
+++ b/emojivoto/emojivoto.yml
@@ -85,20 +85,20 @@ spec:
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: web
+  name: web-svc
   namespace: emojivoto
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: web
+      app: web-svc
   template:
     metadata:
       labels:
-        app: web
+        app: web-svc
     spec:
       containers:
-      - name: emoji-svc
+      - name: web-svc
         image: buoyantio/emojivoto-web:v1
         env:
         - name: WEB_PORT
@@ -112,6 +112,15 @@ spec:
         ports:
         - name: http
           containerPort: 80
+      - name: vote-bot
+        image: buoyantio/emojivoto-web:v1
+        command:
+        - "/bin/sh"
+        args:
+        - "-c"
+        - |
+          sleep 15 # wait for pods to start
+          emojivoto-vote-bot localhost:80
 ---
 apiVersion: v1
 kind: Service
@@ -121,7 +130,7 @@ metadata:
 spec:
   type: LoadBalancer
   selector:
-    app: web
+    app: web-svc
   ports:
   - name: http
     port: 80


### PR DESCRIPTION
The vote-bot script can run in the background and generate traffic to the emojivoto app. I've configured the script to run in our docker-compose and kubernetes configs.