### PR TITLE
Move vot-bot out of web-svc pod into its own deployment

### DIFF
--- a/emojivoto/emojivoto.yml
+++ b/emojivoto/emojivoto.yml
@@ -112,12 +112,6 @@ spec:
         ports:
         - name: http
           containerPort: 80
-      - name: vote-bot
-        image: buoyantio/emojivoto-web:v2
-        command: ["emojivoto-vote-bot"]
-        env:
-        - name: WEB_HOST
-          value: "localhost:80"
 ---
 apiVersion: v1
 kind: Service
@@ -132,3 +126,27 @@ spec:
   - name: http
     port: 80
     targetPort: 80
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: vote-bot
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vote-bot
+  template:
+    metadata:
+      labels:
+        app: vote-bot
+    spec:
+      containers:
+      - name: vote-bot
+        image: buoyantio/emojivoto-web:v2
+        command: ["emojivoto-vote-bot"]
+        env:
+        - name: WEB_HOST
+          value: "web-svc:80"
+


### PR DESCRIPTION
In an effort to gain visibility of downstream requests of vote-bot to web-svc, this PR edits the `emojivoto.yml` to effectively place the vote bot into its own pod. 

A look at the dashboard shows that stats are not being show for the downstream requests and this might be a possible bug? 
<img width="970" alt="screen shot 2018-01-25 at 8 11 24 pm" src="https://user-images.githubusercontent.com/2197104/35425018-96134640-020c-11e8-98b3-ac46e83e63cf.png">
