### PR TITLE
update README

### DIFF
--- a/emojivoto/README.md
+++ b/emojivoto/README.md
@@ -36,7 +36,7 @@ conduit dashboard
 4. Inject, Deploy, and Enjoy
 
 ```
-conduit inject emojivoto.yml --skip-inbound-ports=80 | kubectl apply -f -
+conduit inject emojivoto.yml | kubectl apply -f -
 ```
 
 5. Use the app!


### PR DESCRIPTION
Delete unnecessary `--skip-inbound-ports` flag from minikube install instructions in README

Signed-off-by: Franziska von der Goltz <franziska@vdgoltz.eu>