### PR TITLE
updated test formatting to make test suite pass 

### DIFF
--- a/emojivoto/emojivoto-emoji-svc/api/api_test.go
+++ b/emojivoto/emojivoto-emoji-svc/api/api_test.go
@@ -1,10 +1,11 @@
 package api
 
 import (
+	"context"
 	"testing"
+
 	"github.com/runconduit/conduit-examples/emojivoto/emojivoto-emoji-svc/emoji"
 	pb "github.com/runconduit/conduit-examples/emojivoto/emojivoto-emoji-svc/gen/proto"
-	"context"
 )
 
 func TestListAll(t *testing.T) {
@@ -80,7 +81,7 @@ func TestFindByShortcode(t *testing.T) {
 		}
 
 		if response.Emoji != nil {
-			t.Fatal("Expected to return nil for emoji, returned [%s]", response.Emoji)
+			t.Fatalf("Expected to return nil for emoji, returned [%s]", response.Emoji)
 		}
 	})
 

--- a/emojivoto/emojivoto-voting-svc/api/api_test.go
+++ b/emojivoto/emojivoto-voting-svc/api/api_test.go
@@ -58,11 +58,11 @@ func TestLeaderboard(t *testing.T) {
 		}
 
 		if response.Results[0].Shortcode != votedForTwice || response.Results[0].Votes != 2 {
-			t.Fatalf("Expected results to be [%s,%s], found: [%v]", votedForTwice, 2, response.Results)
+			t.Fatalf("Expected results to be [%v,%v], found: [%v]", votedForTwice, 2, response.Results)
 		}
 
 		if response.Results[1].Shortcode != votedForOnce || response.Results[1].Votes != 1 {
-			t.Fatalf("Expected results to be [%s,%s], found: [%v]", votedForOnce, 1, response.Results)
+			t.Fatalf("Expected results to be [%v,%v], found: [%v]", votedForOnce, 1, response.Results)
 		}
 	})
 }


### PR DESCRIPTION
Previously when trying to make emojivoto run locally, the test suit broke `make all`. 

This PR fixes test formats to make the make build pass as well as pass tests run locally.

Signed-off-by: Franziska von der Goltz <franziska@vdgoltz.eu>