### PR TITLE
Modify lifecycle example for high-scale by default

### DIFF
--- a/lifecycle/README.md
+++ b/lifecycle/README.md
@@ -20,7 +20,30 @@ kubectl create clusterrolebinding cluster-admin-binding-$USER \
   --clusterrole=cluster-admin --user=$(gcloud config get-value account)
 ```
 
-## Deploy
+## Batch Deploy / Scale / Teardown
+
+Deploy 10 lifecycle namespaces:
+
+```bash
+conduit install --conduit-namespace conduit-lifecycle | kubectl apply -f -
+bin/deploy 10
+```
+
+Scale 10 lifecycle namespaces to 3 replicas of `bb-p2p` and `bb-terminus` each:
+
+```bash
+bin/scale 10 3
+```
+
+Teardown 10 lifecycle namespaces:
+
+```bash
+bin/teardown 10
+```
+
+## Individual Deploy / Scale / Teardown
+
+### Deploy
 
 Install Conduit service mesh:
 
@@ -43,7 +66,7 @@ Scale `bb-p2p` and `bb-terminus`:
 kubectl -n $LIFECYCLE_NS scale --replicas=3 deploy/bb-p2p deploy/bb-terminus
 ```
 
-## Observe
+### Observe
 
 Browse to Grafana:
 
@@ -63,30 +86,9 @@ Relevant Grafana dashboards to observe
 - `Conduit Deployment`, for route lifecycle and service discovery lifecycle
 - `Prometheus 2.0 Stats`, for telemetry resource lifecycle
 
-## Teardown
+### Teardown
 
 ```bash
 kubectl delete ns $LIFECYCLE_NS
 kubectl delete ns conduit-lifecycle
-```
-
-## Batch Deploy / Scale / Teardown
-
-Deploy 10 lifecycle namespaces:
-
-```bash
-conduit install --conduit-namespace conduit-lifecycle | kubectl apply -f -
-bin/deploy 10
-```
-
-Scale 10 lifecycle namespaces to 3 replicas of `bb-p2p` and `bb-terminus` each:
-
-```bash
-bin/scale 10 3
-```
-
-Teardown 10 lifecycle namespaces:
-
-```bash
-bin/teardown 10
 ```

--- a/lifecycle/lifecycle.yml
+++ b/lifecycle/lifecycle.yml
@@ -188,14 +188,14 @@ data:
       POD_COUNT=$(($SPACES+1))
       echo "found ${POD_COUNT} pods"
 
-      # restart each pod every minute
-      SLEEP_TIME=$(( 60 / $POD_COUNT))
-      if [ $SLEEP_TIME = 0 ]; then
-        SLEEP_TIME=1
-      fi
+      SLEEP_TIME=60
 
-      # TODO: consider overriding the calculation above, to better accomodate large deployments
-      # SLEEP_TIME=30
+      # more aggressive restart interval, for smaller deployments
+      # restart each pod every minute
+      # SLEEP_TIME=$(( 60 / $POD_COUNT))
+      # if [ $SLEEP_TIME = 0 ]; then
+      #   SLEEP_TIME=1
+      # fi
 
       for POD in ${PODS}; do
         kubectl -n $LIFECYCLE_NS delete po $POD


### PR DESCRIPTION
Update the lifecycle README.md to put the batch deploy / scale
instructions front and center. Increase the redeploy interval to better
accomodate batch deployments.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>