### PR TITLE
Fix voting-svc to support concurrent votes

### DIFF
--- a/emojivoto/Dockerfile
+++ b/emojivoto/Dockerfile
@@ -1,4 +1,4 @@
-FROM buoyantio/emojivoto-svc-base:v3
+FROM buoyantio/emojivoto-svc-base:v4
 
 ARG svc_name
 

--- a/emojivoto/Makefile
+++ b/emojivoto/Makefile
@@ -1,9 +1,11 @@
-.PHONY: web emoji-svc voting-svc integration-tests
+include ./common.mk
+
+.PHONY: web emoji-svc voting-svc integration-tests push
 
 all: build integration-tests
 
 build-base-docker-image:
-	docker build . -f Dockerfile-base -t "buoyantio/emojivoto-svc-base:v3"
+	docker build . -f Dockerfile-base -t "buoyantio/emojivoto-svc-base:$(IMAGE_TAG)"
 
 web:
 	$(MAKE) -C emojivoto-web
@@ -14,7 +16,6 @@ emoji-svc:
 voting-svc:
 	$(MAKE) -C emojivoto-voting-svc
 
-
 build: web emoji-svc voting-svc
 
 deploy-to-minikube:
@@ -23,7 +24,6 @@ deploy-to-minikube:
 	$(MAKE) -C emojivoto-voting-svc build-container
 	kubectl delete -f emojivoto.yml || echo "ok"
 	kubectl apply -f emojivoto.yml
-
 
 deploy-to-docker-compose:
 	docker-compose stop
@@ -37,3 +37,8 @@ integration-tests: deploy-to-docker-compose
 	WEB_URL=http://localhost:8080 $(MAKE) -C integration_test test
 	docker-compose stop
 	docker-compose rm -vf
+
+push-%:
+	docker push buoyantio/emojivoto-$*:$(IMAGE_TAG)
+
+push: push-svc-base push-emoji-svc push-voting-svc push-web

--- a/emojivoto/README.md
+++ b/emojivoto/README.md
@@ -86,10 +86,10 @@ To update the docker images:
 5. Push the docker images to hub.docker.com
 ```bash
 docker login
-docker push buoyantio/emojivoto-svc-base:v3
-docker push buoyantio/emojivoto-emoji-svc:v3
-docker push buoyantio/emojivoto-voting-svc:v3
-docker push buoyantio/emojivoto-web:v3
+docker push buoyantio/emojivoto-svc-base:v4
+docker push buoyantio/emojivoto-emoji-svc:v4
+docker push buoyantio/emojivoto-voting-svc:v4
+docker push buoyantio/emojivoto-web:v4
 ```
 6. Update `emojivoto.yml`, `docker-compose.yml`
 

--- a/emojivoto/common.mk
+++ b/emojivoto/common.mk
@@ -1,3 +1,5 @@
+export IMAGE_TAG := v4
+
 .PHONY: package protoc test
 
 target_dir := target
@@ -17,7 +19,7 @@ protoc:
 package: protoc dep compile build-container
 
 build-container:
-	docker build .. -t "buoyantio/$(svc_name):v3" --build-arg svc_name=$(svc_name)
+	docker build .. -t "buoyantio/$(svc_name):$(IMAGE_TAG)" --build-arg svc_name=$(svc_name)
 
 compile:
 	GOOS=linux go build -v -o $(target_dir)/$(svc_name) cmd/server.go

--- a/emojivoto/docker-compose.yml
+++ b/emojivoto/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   web:
-    image: buoyantio/emojivoto-web:v3
+    image: buoyantio/emojivoto-web:v4
     environment:
       - WEB_PORT=8080
       - EMOJISVC_HOST=emoji-svc:8080
@@ -15,7 +15,7 @@ services:
       - emoji-svc
 
   vote-bot:
-    image: buoyantio/emojivoto-web:v3
+    image: buoyantio/emojivoto-web:v4
     entrypoint: emojivoto-vote-bot
     environment:
       - WEB_HOST=web:8080
@@ -23,14 +23,14 @@ services:
       - web
 
   emoji-svc:
-    image: buoyantio/emojivoto-emoji-svc:v3
+    image: buoyantio/emojivoto-emoji-svc:v4
     environment:
       - GRPC_PORT=8080
     ports:
       - "8081:8080"
 
   voting-svc:
-    image: buoyantio/emojivoto-voting-svc:v3
+    image: buoyantio/emojivoto-voting-svc:v4
     environment:
       - GRPC_PORT=8080
     ports:

--- a/emojivoto/emojivoto-voting-svc/voting/poll.go
+++ b/emojivoto/emojivoto-voting-svc/voting/poll.go
@@ -26,12 +26,12 @@ type Poll interface {
 
 type inMemoryPoll struct {
 	votes map[string]int
-	mutex sync.RWMutex
+	sync.RWMutex
 }
 
 func (p *inMemoryPoll) Vote(choice string) error {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
+	p.Lock()
+	defer p.Unlock()
 
 	if p.votes[choice] > 0 {
 		p.votes[choice] = p.votes[choice] + 1
@@ -43,8 +43,8 @@ func (p *inMemoryPoll) Vote(choice string) error {
 }
 
 func (p *inMemoryPoll) Results() ([]*Result, error) {
-	p.mutex.RLock()
-	defer p.mutex.RUnlock()
+	p.RLock()
+	defer p.RUnlock()
 
 	results := make([]*Result, 0)
 
@@ -60,6 +60,5 @@ func (p *inMemoryPoll) Results() ([]*Result, error) {
 func NewPoll() Poll {
 	return &inMemoryPoll{
 		votes: make(map[string]int, 0),
-		mutex: sync.RWMutex{},
 	}
 }

--- a/emojivoto/emojivoto.yml
+++ b/emojivoto/emojivoto.yml
@@ -26,7 +26,7 @@ spec:
       - env:
         - name: GRPC_PORT
           value: "8080"
-        image: buoyantio/emojivoto-emoji-svc:v3
+        image: buoyantio/emojivoto-emoji-svc:v4
         name: emoji-svc
         ports:
         - containerPort: 8080
@@ -70,7 +70,7 @@ spec:
       - env:
         - name: GRPC_PORT
           value: "8080"
-        image: buoyantio/emojivoto-voting-svc:v3
+        image: buoyantio/emojivoto-voting-svc:v4
         name: voting-svc
         ports:
         - containerPort: 8080
@@ -120,7 +120,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v4
         name: web-svc
         ports:
         - containerPort: 80
@@ -166,7 +166,7 @@ spec:
         env:
         - name: WEB_HOST
           value: web-svc.emojivoto:80
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v4
         name: vote-bot
         resources: {}
 status: {}


### PR DESCRIPTION
The service will crash when there is instantaneous access to the map.

Wrap voting access in a mutex.