### PR TITLE
Introduce baseline and TLS configs to lifecycle

### DIFF
--- a/lifecycle/README.md
+++ b/lifecycle/README.md
@@ -22,26 +22,27 @@ kubectl create clusterrolebinding cluster-admin-binding-$USER \
 
 ## Batch Deploy / Scale / Teardown
 
-Deploy 5 lifecycle namespaces:
+Deploy 3 lifecycle environments:
 
 ```bash
-conduit install --conduit-namespace conduit-lifecycle --tls optional | kubectl apply -f -
-bin/deploy 5
+conduit install --conduit-namespace conduit-lifecycle | kubectl apply -f -
+conduit install --conduit-namespace conduit-lifecycle-tls --tls optional | kubectl apply -f -
+bin/deploy 3
 ```
 
-Scale 5 lifecycle namespaces to 3 replicas of `bb-broadcast`, `bb-p2p`, and
+Scale 3 lifecycle environments to 3 replicas of `bb-broadcast`, `bb-p2p`, and
 `bb-terminus` each:
 
 ```bash
-bin/scale 5 3
+bin/scale 3 3
 ```
 
-Total mesh-enabled pod count == namespaces * (3*replicas+2)
+Total mesh-enabled pod count == (1 conduit ns + 1 conduit tls ns) * (3*replicas+2)
 
-Teardown 5 lifecycle namespaces:
+Teardown 3 lifecycle environments:
 
 ```bash
-bin/teardown 5
+bin/teardown 3
 ```
 
 ## Individual Deploy / Scale / Teardown

--- a/lifecycle/bin/deploy
+++ b/lifecycle/bin/deploy
@@ -9,15 +9,28 @@ if [ "$NAMESPACES" -gt 100 ]; then
   exit 1
 fi
 
-echo "Deploying $NAMESPACES namespaces..."
+echo "Deploying $NAMESPACES injected, TLS, and baseline namespaces..."
 
 for i in `seq 1 $NAMESPACES`;
 do
   NS=lifecycle$i
+  NS_TLS=$NS-tls
+  NS_BASELINE=$NS-baseline
 
   echo "\nDeploying $NS..."
   kubectl create ns $NS
   cat lifecycle.yml |
-    conduit inject --conduit-namespace conduit-lifecycle --tls optional - |
+    conduit inject --conduit-namespace conduit-lifecycle - |
     kubectl -n $NS apply -f -
+
+  echo "\nDeploying $NS_TLS..."
+  kubectl create ns $NS_TLS
+  cat lifecycle.yml |
+    conduit inject --conduit-namespace conduit-lifecycle-tls --tls optional - |
+    kubectl -n $NS_TLS apply -f -
+
+  echo "\nDeploying $NS_BASELINE..."
+  kubectl create ns $NS_BASELINE
+  cat lifecycle.yml |
+    kubectl -n $NS_BASELINE apply -f -
 done

--- a/lifecycle/bin/scale
+++ b/lifecycle/bin/scale
@@ -5,6 +5,11 @@ set -e
 NAMESPACES=${1:-1}
 REPLICAS=${2:-1}
 
+function scale() {
+  echo "\nScaling $1 to $REPLICAS replicas..."
+  kubectl -n $1 scale --replicas=$REPLICAS deploy/bb-broadcast deploy/bb-p2p deploy/bb-terminus
+}
+
 if [ "$NAMESPACES" -gt 100 ]; then
   echo "Don't deploy more than 100 namespaces"
   exit 1
@@ -15,12 +20,13 @@ if [ "$REPLICAS" -gt 100 ]; then
   exit 1
 fi
 
-echo "Scaling $NAMESPACES namespaces to $REPLICAS replicas..."
+echo "Scaling $NAMESPACES injected, TLS, and baseline namespaces to $REPLICAS replicas..."
 
 for i in `seq 1 $NAMESPACES`;
 do
   NS=lifecycle$i
 
-  echo "\nScaling $NS to $REPLICAS replicas..."
-  kubectl -n lifecycle$i scale --replicas=$REPLICAS deploy/bb-broadcast deploy/bb-p2p deploy/bb-terminus
+  scale "$NS"
+  scale "$NS-tls"
+  scale "$NS-baseline"
 done

--- a/lifecycle/bin/teardown
+++ b/lifecycle/bin/teardown
@@ -4,9 +4,15 @@ set -e
 
 NAMESPACES=${1:-1}
 
-echo "Tearing down $NAMESPACES namespaces...\n"
+echo "Tearing down $NAMESPACES injected, TLS, and baseline namespaces...\n"
 
 for i in `seq 1 $NAMESPACES`;
 do
-  kubectl delete ns lifecycle$i || true
+  NS=lifecycle$i
+  NS_TLS=$NS-tls
+  NS_BASELINE=$NS-baseline
+
+  kubectl delete ns $NS || true
+  kubectl delete ns $NS_TLS || true
+  kubectl delete ns $NS_BASELINE || true
 done


### PR DESCRIPTION
The existing lifecycle test environment runs a set of applications
injected with Conduit.

This change introduces a parallel set of applications that run without
Conduit, to enable comparison.

Part of #43.

Depends on runconduit/conduit#1295.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>